### PR TITLE
Document Graphite PR workflow policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,4 +109,12 @@ BEHAVIORAL DECORATORS:
     4. present the methodology to the user using the ASK USER TOOL
 
     **CRITICAL**: Always give your candid and honest opinion. never equivocate and always push back if you feel the user is wrong or suggesting something obviously suboptimal.
+
+## PR Workflow Policy (Graphite)
+
+- Use Graphite stacks for all PRs; do not open PRs directly in GitHub.
+- Target all feature stacks to `dev`.
+- Keep the rolling `dev` → `master` PR open as the release train.
+- Review and merge stacks bottom → top.
+- When ready to release, merge the `dev` → `master` PR.
 <!-- MANUAL ADDITIONS END -->


### PR DESCRIPTION
### TL;DR

Added PR workflow policy for Graphite to the CLAUDE.md document.

### What changed?

Added a new section titled "PR Workflow Policy (Graphite)" to CLAUDE.md that outlines the process for handling pull requests using Graphite. The policy includes five key points:
- Using Graphite stacks for all PRs instead of GitHub
- Targeting feature stacks to `dev` branch
- Maintaining an open `dev` → `master` PR as the release train
- Reviewing and merging stacks from bottom to top
- Merging the `dev` → `master` PR when ready to release

### How to test?

Review the CLAUDE.md file to ensure the new PR workflow policy section appears correctly at the end of the document and that the formatting is consistent with the rest of the document.

### Why make this change?

To establish and document a standardized workflow for managing pull requests using Graphite, ensuring consistency in the development process and providing clear guidelines for the team to follow when submitting and reviewing code changes.