### PR TITLE
chore(ci): use GitHub App token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Generate token from GitHub App
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:
@@ -47,7 +54,7 @@ jobs:
           commit: "chore: version packages"
           title: "chore: version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
   publish:
     name: Publish to npm


### PR DESCRIPTION
## Summary

Switches the release workflow from the default GITHUB_TOKEN to a token generated from a GitHub App. This allows the workflow to bypass branch protection rules and create PRs for version bumps.

## What changed

- Added step to generate token from GitHub App using `actions/create-github-app-token@v1`
- Updated changesets action to use the generated token
- Requires `RELEASE_BOT_APP_ID` and `RELEASE_BOT_PRIVATE_KEY` secrets

## Setup required

See https://github.com/Open-Harness/open-harness/pull/XXX for GitHub App setup instructions.

## Why

The default GITHUB_TOKEN doesn't have permission to create PRs due to branch protection rules. Using a GitHub App token with proper permissions allows automated version bump PRs.