### PR TITLE
fix(docs): resolve broken homepage links

### DIFF
--- a/apps/docs/content/docs/reference/index.mdx
+++ b/apps/docs/content/docs/reference/index.mdx
@@ -1,0 +1,43 @@
+---
+title: Reference
+description: Complete API reference and technical documentation for Open Harness
+---
+
+# Reference Documentation
+
+Complete technical reference for Open Harness — APIs, types, schemas, and expressions.
+
+## API Reference
+
+Core SDK APIs for building agent workflows:
+
+- [Hub](/docs/reference/api/hub) - Orchestrates flow execution and manages runtime state
+- [Agent](/docs/reference/api/agent) - Wraps AI model interactions (Claude, GPT, etc.)
+- [Channel](/docs/reference/api/channel) - Connects agents with structured message passing
+- [Flow Runtime](/docs/reference/api/flow-runtime) - Executes flows and manages node lifecycle
+- [Events](/docs/reference/api/events) - Event system for monitoring and debugging
+- [Node Registry](/docs/reference/api/node-registry) - Registers and resolves flow nodes
+- [Run Store](/docs/reference/api/run-store) - Persists execution history and state
+
+## Expressions
+
+Dynamic data access in flows:
+
+- [Syntax](/docs/reference/expressions/syntax) - JSONata expression syntax
+- [Context](/docs/reference/expressions/context) - Available runtime context
+- [Functions](/docs/reference/expressions/functions) - Built-in expression functions
+
+## Type Definitions
+
+TypeScript types for flows and runtime:
+
+- [Flow Definition](/docs/reference/types/flow-definition) - Complete flow structure
+- [Node Definition](/docs/reference/types/node-definition) - Node configuration types
+- [Edge Definition](/docs/reference/types/edge-definition) - Flow connections
+- [Runtime Event](/docs/reference/types/runtime-event) - Event payloads
+
+## Schemas
+
+YAML schemas for flow specifications:
+
+- [Flow YAML](/docs/reference/schemas/flow-yaml) - FlowSpec YAML schema

--- a/apps/docs/src/app/(home)/page.tsx
+++ b/apps/docs/src/app/(home)/page.tsx
@@ -13,7 +13,7 @@ export default function HomePage() {
 				</p>
 				<div className="flex gap-4 justify-center mb-12">
 					<Link
-						href="/docs/learn"
+						href="/docs/learn/quickstart"
 						className="px-6 py-3 bg-primary text-primary-foreground rounded-md font-medium hover:bg-primary/90 transition-colors"
 					>
 						Get Started


### PR DESCRIPTION
Fixes broken links on the docs homepage that weren't caught by the link linter.

## Changes
- Fixed 'Get Started' button to link to `/docs/learn/quickstart` instead of non-existent `/docs/learn`
- Created `/docs/reference/index.mdx` landing page with comprehensive overview of all reference sections (API, expressions, types, schemas)

## Validation
- ✅ Link linter passes (31/31 internal links valid)
- ✅ Manually tested both homepage buttons
- ✅ All reference section links work correctly

Closes open-harness-3ej