### PR TITLE
fix(changeset): remove references to deleted packages

### DIFF
--- a/.changeset/alpha-release-sdk.md
+++ b/.changeset/alpha-release-sdk.md
@@ -4,8 +4,6 @@
 "@open-harness/client": minor
 "@open-harness/react": minor
 "@open-harness/testing": minor
-"@open-harness/run-store-sqlite": minor
-"@open-harness/run-store-testing": minor
 ---
 
 Initial alpha release of Open Harness SDK


### PR DESCRIPTION
## Summary
- Remove `@open-harness/run-store-sqlite` and `@open-harness/run-store-testing` from alpha-release-sdk changeset
- These packages were removed in v0.3.0 but the changeset still referenced them
- This was causing the release workflow to fail

## Context
The release workflow failed with:
```
Error: Found changeset alpha-release-sdk for package @open-harness/run-store-sqlite which is not in the workspace
```

This is a hotfix to unblock the v0.3.0-alpha.0 release.