### PR TITLE
fix(changeset): remove references to deleted packages

### DIFF
--- a/.changeset/alpha-release-sdk.md
+++ b/.changeset/alpha-release-sdk.md
@@ -4,8 +4,6 @@
 "@open-harness/client": minor
 "@open-harness/react": minor
 "@open-harness/testing": minor
-"@open-harness/run-store-sqlite": minor
-"@open-harness/run-store-testing": minor
 ---
 
 Initial alpha release of Open Harness SDK


### PR DESCRIPTION
## Summary

Fixes the release workflow which was failing because `alpha-release-sdk.md` referenced packages that were deleted in v0.3.0:
- `@open-harness/run-store-sqlite`
- `@open-harness/run-store-testing`

Also syncs dev with master after the v0.3.0 merge.

## Changes

- Removed references to deleted packages from `.changeset/alpha-release-sdk.md`
- Merged master into dev to sync branches

## Test plan

- [ ] Release workflow should now succeed
- [ ] Changesets should process without errors

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)